### PR TITLE
Allow optional whitelist of allowed claims

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       minitest (~> 5.0)
     rack (1.5.2)
     rake (10.1.0)
-    ruby-openid (2.3.0)
+    ruby-openid (2.7.0)
 
 PLATFORMS
   ruby
@@ -32,3 +32,6 @@ DEPENDENCIES
   rack-openid!
   rake
   rots!
+
+BUNDLED WITH
+   2.0.1


### PR DESCRIPTION
## Usage

``` ruby
# application.rb
module App
  class Application < Rails::Application
    valid_claim_patterns = [
      /^https:\/\/openid\.provider\.com\/identity\-[a-z0-9]{8}$/,
    ]
    openid_store = OpenID::Store::Redis.new(redis)
    config.middleware.use Rack::OpenID, openid_store, valid_claim_patterns: valid_claim_patterns
  end
end
```